### PR TITLE
ステップ11：タスク一覧を作成日時の順番で並び替えよう

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,7 +1,7 @@
 class TasksController < ApplicationController
   before_action :set_task,only: %i(show edit destroy update)
   def index
-    @tasks = Task.all
+    @tasks = Task.all.order(created_at: :desc)
   end
 
   def new

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -1,0 +1,20 @@
+FactoryBot.define do
+
+  factory :task do
+    title {"タイトル1"}
+    content {"本文1 "}
+    created_at {Time.current + 1.days}
+  end
+
+  factory :second_task,class: Task do
+    title {"タイトル2"}
+    content {"本文2"}
+    created_at {Time.current + 2.days}
+  end
+
+  factory :third_task,class: Task do
+    title {"タイトル3"}
+    content {"本文3"}
+    created_at {Time.current + 3.days}
+  end
+end

--- a/spec/features/task.spec.rb
+++ b/spec/features/task.spec.rb
@@ -1,32 +1,43 @@
 require 'rails_helper'
 
 RSpec.feature "タスク管理機能",type: :feature do
-  scenario "タスク一覧のテスト" do
-    Task.create!(title:"テストタイトル1",content:"テスト本文1")
-    Task.create!(title:"テストタイトル2",content:"テスト本文2")
 
+  background do
+    FactoryBot.create(:task)
+    FactoryBot.create(:second_task)
+    FactoryBot.create(:third_task)
+  end
+
+  scenario "タスク一覧のテスト" do
     visit tasks_path
 
-    expect(page).to have_content "テストタイトル1"
-    expect(page).to have_content "テストタイトル2"
+    expect(page).to have_content "タイトル1"
+    expect(page).to have_content "タイトル2"
+    expect(page).to have_content "タイトル3"
   end
 
   scenario "タスク作成のテスト" do
     visit new_task_path
 
-    fill_in "Title", with: "テストタイトル3"
-    fill_in "Content", with: "テスト本文3"
+    fill_in "Title", with: "タイトル4"
+    fill_in "Content", with: "本文4"
 
-    click_on "Create Task"
+    click_on "登録する"
 
-    expect(page).to have_content "テストタイトル3"
+    expect(page).to have_content "タイトル4"
   end
 
   scenario "タスク詳細のテスト" do
-    task = Task.create!(title:"テストタイトル4",content:"テスト本文4")
+    task = Task.create!(title:"タイトル5",content:"本文5")
 
     visit task_path(task.id)
 
-    expect(page).to have_content "テスト本文4"
+    expect(page).to have_content "本文5"
+  end
+
+  scenario "タスクが作成日時の降順に並んでいるかのテスト" do
+    visit tasks_path
+    click_on "詳細",match: :first
+    expect(page).to have_content "タイトル3"
   end
 end


### PR DESCRIPTION
・タスク一覧が作成日時の降順で表示されるように修正
・タスク一覧が作成日時の降順で表示されるかのテスト追加